### PR TITLE
fix: github contribution URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ This plugin utilizes document-based retrieval from the Knowledge Base to enhance
 
 We welcome contributions from the community! Whether you want to report a bug, suggest new features, or submit a pull request, your input is valuable to us.
 
-Please refer to our contribution policy first : [How to contribute to Hexabot](./CONTRIBUTING.md)
+Please refer to our contribution policy first : [How to contribute to Hexabot](https://github.com/Hexastack/Hexabot/blob/main/CONTRIBUTING.md)
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/Hexastack/Hexabot/blob/main/CODE_OF_CONDUCT.md)
 
 Feel free to join us on [Discord](https://discord.gg/rNb9t2MFkG)
 


### PR DESCRIPTION
# Motivation
The main motivation is to make absolute the contribution and the code of conduct URLs to be able to accessible from multiple platform (For example: NPM)